### PR TITLE
Support pre netCDF 1.6.0 compression kwarg formatting

### DIFF
--- a/tropess_compression/compress_tropess_file.py
+++ b/tropess_compression/compress_tropess_file.py
@@ -12,6 +12,12 @@ DEFAULT_COMPRESSION_VAR_RE = r'^(.*averaging_kernel)|(.+_covariance)$'
 
 DEFAULT_MAX_ERROR = 0.00005 
 
+# Support pre and post netCDF v1.6.0 compression kwarg formatting
+compression_kwarg = {'compression': 'zlib'}
+ver_parts = list(map(int, netCDF4.__version__.split('.')))
+if ver_parts[0] == 1 and ver_parts[1] < 6:
+    compression_kwarg = {'zlib': True}
+
 logger = logging.getLogger()
 
 def compress_variable(data_file_input, data_file_output, var_name, max_error=DEFAULT_MAX_ERROR, progress_bar=False):
@@ -28,7 +34,7 @@ def compress_variable(data_file_input, data_file_output, var_name, max_error=DEF
     # to have been removed from the output data file
     dim_name = data_file_input[var_name].name + "_compressed_bytes"
     out_dim = data_file_output.createDimension(dim_name, len(compressed_data))
-    out_var = data_file_output.createVariable(var_name, np.byte, (dim_name,), fill_value=fill_value, compression='zlib')
+    out_var = data_file_output.createVariable(var_name, np.byte, (dim_name,), fill_value=fill_value, **compression_kwarg)
     out_var[...] = compressed_data
 
     # Copy attributes from source variable, except for certain ignored ones

--- a/tropess_compression/decompress_tropess_file.py
+++ b/tropess_compression/decompress_tropess_file.py
@@ -11,6 +11,12 @@ COMPRESS_DIMENSIONS_RE = r'.*_compressed_bytes'
 
 logger = logging.getLogger()
 
+# Support pre and post netCDF v1.6.0 compression kwarg formatting
+compression_kwarg = {'compression': 'zlib'}
+ver_parts = list(map(int, netCDF4.__version__.split('.')))
+if ver_parts[0] == 1 and ver_parts[1] < 6:
+    compression_kwarg = {'zlib': True}
+
 def decompress_variable(data_file_input, data_file_output, var_name, progress_bar=False):
 
     # Read input data
@@ -27,7 +33,7 @@ def decompress_variable(data_file_input, data_file_output, var_name, progress_ba
     decompress_dtype = data_file_input[var_name].uncompressed_data_type
     decompress_fill_value = data_file_input[var_name].uncompressed_fill_value
 
-    out_var = data_file_output.createVariable(var_name, decompress_dtype, decompress_dims, fill_value=decompress_fill_value, compression='zlib')
+    out_var = data_file_output.createVariable(var_name, decompress_dtype, decompress_dims, fill_value=decompress_fill_value, **compression_kwarg)
     out_var[...] = decompressed_data
 
     # Copy attributes from source variable, except for certain ignored ones


### PR DESCRIPTION
Update netCDF4 compression kwarg handling to support the pre v1.6.0
`zlib=True` compression format in addition to the current
`compression='<type>'` format. This allows for compatibility with
libraries running (very) old netCDF4 versions.

Note, if we don't want to support both of these formats we should
probably be pinning our dependencies to avoid this issue.
