### PR TITLE
Gracefully handle variables without a _FillValue attribute

### DIFF
--- a/tropess_compression/compress_tropess_file.py
+++ b/tropess_compression/compress_tropess_file.py
@@ -23,7 +23,11 @@ logger = logging.getLogger()
 def compress_variable(data_file_input, data_file_output, var_name, max_error=DEFAULT_MAX_ERROR, progress_bar=False):
 
     # Read input data
-    fill_value = data_file_input[var_name]._FillValue
+    # Gracefully (maybe?) handle variables that are missing _FillValue. We should
+    # fully shift away from using missing_value in the future. We should also use
+    # an up-to-date version of netCDF4 so we could use variable.get_fill_value()
+    # instead of this ... thing.
+    fill_value = data_file_input[var_name]._FillValue = data_file_input[var_name]._FillValue if hasattr(data_file_input[var_name], '_FillValue') else data_file_input[var_name].missing_value
     data_input = data_file_input[var_name][...].filled(fill_value)
 
     # Perform compression

--- a/tropess_compression/decompress_tropess_file.py
+++ b/tropess_compression/decompress_tropess_file.py
@@ -20,7 +20,11 @@ if ver_parts[0] == 1 and ver_parts[1] < 6:
 def decompress_variable(data_file_input, data_file_output, var_name, progress_bar=False):
 
     # Read input data
-    fill_value = data_file_input[var_name]._FillValue
+    # Gracefully (maybe?) handle variables that are missing _FillValue. We should
+    # fully shift away from using missing_value in the future. We should also use
+    # an up-to-date version of netCDF4 so we could use variable.get_fill_value()
+    # instead of this ... thing.
+    fill_value = data_file_input[var_name]._FillValue = data_file_input[var_name]._FillValue if hasattr(data_file_input[var_name], '_FillValue') else data_file_input[var_name].missing_value
     compressed_input = data_file_input[var_name][...].filled(fill_value)
 
     # Perform decompression


### PR DESCRIPTION
Fall back to `missing_value` if we encounter a variable that is missing the `_FillValue` attribute. We should be able to avoid this in the future by switching over fully to `_FillValue` and / or leveraging APIs (`var.get_fill_value()`) in newer netCDF4 versions for retrieving this value.